### PR TITLE
Fix padding for strings that are multiples of 16

### DIFF
--- a/lib/fernetex.ex
+++ b/lib/fernetex.ex
@@ -250,10 +250,7 @@ defmodule Fernet do
   end
 
   defp pad(message) do
-    case rem(byte_size(message), 16) do
-      0 -> message
-      r -> message <> padding(16 - r)
-    end
+    message <> padding(16 - rem(byte_size(message), 16))
   end
 
   defp padding(len) do

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,8 @@ defmodule Fernet.Mixfile do
      {:dialyxir, "~> 0.5", only: :dev},
      {:earmark, "~> 1.2", only: :dev},
      {:ex_doc, "~> 0.15", only: :dev},
-     {:poison , "~> 3.1", only: :test}
+     {:poison , "~> 3.1", only: :test},
+     {:propcheck, "~> 1.0", only: :test}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -11,6 +11,8 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "propcheck": {:hex, :propcheck, "1.0.6", "c206366e4870432be73eedd7309e2e2a489561b52f355f709dc500ee8386a873", [:mix], [{:proper, "~> 1.2.0", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
+  "proper": {:hex, :proper, "1.2.0", "1466492385959412a02871505434e72e92765958c60dba144b43863554b505a4", [:make, :mix, :rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "timex": {:hex, :timex, "3.1.13", "48b33162e3ec33e9a08fb5f98e3f3c19c3e328dded3156096c1969b77d33eef0", [:mix], [{:combine, "~> 0.7", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "tzdata": {:hex, :tzdata, "0.5.12", "1c17b68692c6ba5b6ab15db3d64cc8baa0f182043d5ae9d4b6d35d70af76f67b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"}}


### PR DESCRIPTION
Strings that are multiples of 16 were not being padded so the last character was improperly treated as the padding.

Added test based on issue #8.

Added invariant to test that we can always verify what we generate.
